### PR TITLE
Fix body scroll lock to prevent layout shift

### DIFF
--- a/packages/uikit/src/components/Overlay/Overlay.tsx
+++ b/packages/uikit/src/components/Overlay/Overlay.tsx
@@ -40,15 +40,21 @@ const StyledOverlay = styled(Box)<{ isUnmounting?: boolean }>`
 const BodyLock = () => {
   useEffect(() => {
     if (document?.body?.style) {
-      document.body.style.cssText = `
-      overflow: hidden;
-    `;
+      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+      const previousOverflow = document.body.style.overflow;
+      const previousPaddingRight = document.body.style.paddingRight;
+
       document.body.style.overflow = "hidden";
+      if (scrollbarWidth > 0) {
+        document.body.style.paddingRight = `${scrollbarWidth}px`;
+      }
+
       return () => {
-        document.body.style.cssText = `
-        overflow: visible;
-        overflow: overlay;
-      `;
+        document.body.style.overflow = previousOverflow || "visible";
+        document.body.style.paddingRight = previousPaddingRight;
+        if (!previousOverflow) {
+          document.body.style.overflow = "overlay";
+        }
       };
     }
 


### PR DESCRIPTION
## Summary
- add padding-right to body to offset scrollbar
- restore previous body styles after closing modal

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.6.5.tgz)*
- `pnpm test:config` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.6.5.tgz)*